### PR TITLE
Adding Support for Key Pair Authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 *The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).*
 
+## [2.5.0] - 2020-12-14
+
+### Added
+- Support for encrypted key pair authentication
+
 ## [2.4.0] - 2020-11-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ In the event both authentication criteria are provided, snowchange will prioriti
 The Snowflake user password for `SNOWFLAKE_USER` is required to be set in the environment variable `SNOWSQL_PWD` prior to calling the script. snowchange will fail if the `SNOWSQL_PWD` environment variable is not set.
 
 #### Private Key Authentication
-The Snowflake user private key for `SNOWFLAKE_USER` is required to be in a file with the file path set in the environment variable `PRIVATE_KEY_PATH`. Additionally, the password for the private key file is required to be set in the environment variable `PRIVATE_KEY_PASSPHRASE`. These two environment variables must be set prior to calling the script. snowchange will fail if the `PRIVATE_KEY_PATH` and `PRIVATE_KEY_PASSPHRASE` environment variables are not set.
+The Snowflake user encrypted private key for `SNOWFLAKE_USER` is required to be in a file with the file path set in the environment variable `PRIVATE_KEY_PATH`. Additionally, the password for the encrypted private key file is required to be set in the environment variable `PRIVATE_KEY_PASSPHRASE`. These two environment variables must be set prior to calling the script. snowchange will fail if the `PRIVATE_KEY_PATH` and `PRIVATE_KEY_PASSPHRASE` environment variables are not set.
 
 ### Script Parameters
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,9 @@ snowchange supports both [password authentication](https://docs.snowflake.com/en
 In the event both authentication criteria are provided, snowchange will prioritize password authentication.
 
 #### Password Authentication
-The Snowflake user password for `SNOWFLAKE_USER` is required to be set in the environment variable `SNOWSQL_PWD` prior to calling the script. snowchange will fail if the `SNOWSQL_PWD` environment variable is not set.
+The Snowflake user password for `SNOWFLAKE_USER` is required to be set in the environment variable `SNOWFLAKE_PASSWORD` prior to calling the script. snowchange will fail if the `SNOWFLAKE_PASSWORD` environment variable is not set.
+
+_**DEPRECATION NOTICE**: The `SNOWSQL_PWD` environment variable is deprecated but currently still supported. Support for it will be removed in a later version of snowchange. Please use `SNOWFLAKE_PASSWORD` instead._
 
 #### Private Key Authentication
 The Snowflake user encrypted private key for `SNOWFLAKE_USER` is required to be in a file with the file path set in the environment variable `PRIVATE_KEY_PATH`. Additionally, the password for the encrypted private key file is required to be set in the environment variable `PRIVATE_KEY_PASSPHRASE`. These two environment variables must be set prior to calling the script. snowchange will fail if the `PRIVATE_KEY_PATH` and `PRIVATE_KEY_PASSPHRASE` environment variables are not set.
@@ -233,11 +235,11 @@ docker run -it --rm \
   -e SNOWFLAKE_USER \
   -e SNOWFLAKE_ROLE \
   -e SNOWFLAKE_WAREHOUSE \
-  -e SNOWSQL_PWD \
+  -e SNOWFLAKE_PASSWORD \
   python:3 /bin/bash -c "pip install snowchange --upgrade && snowchange -f $ROOT_FOLDER -a $SNOWFLAKE_ACCOUNT -u $SNOWFLAKE_USER -r $SNOWFLAKE_ROLE -w $SNOWFLAKE_WAREHOUSE"
 ```
 
-Either way, don't forget to set the `SNOWSQL_PWD` environment variable!
+Either way, don't forget to set the `SNOWFLAKE_PASSWORD` environment variable if using password authentication!
 
 ## Maintainers
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ For the complete list of changes made to snowchange check out the [CHANGELOG](CH
 1. [Running snowchange](#running-snowchange)
    1. [Prerequisites](#prerequisites)
    1. [Running The Script](#running-the-script)
+   1. [Authentication](#authentication)
+      1. [Password Authentication](#password-authentication)
+      1. [Private Key Authentication](#private-key-authentication)
    1. [Script Parameters](#script-parameters)
 1. [Getting Started with snowchange](#getting-started-with-snowchange)
 1. [Integrating With DevOps](#integrating-with-devops)
@@ -158,7 +161,16 @@ Or if installed via `pip`, it can be executed as follows:
 snowchange [-h] [-f ROOT_FOLDER] -a SNOWFLAKE_ACCOUNT -u SNOWFLAKE_USER -r SNOWFLAKE_ROLE -w SNOWFLAKE_WAREHOUSE  [-c CHANGE_HISTORY_TABLE] [-v] [-ac]
 ```
 
+### Authentication
+snowchange supports both [password authentication](https://docs.snowflake.com/en/user-guide/python-connector-example.html#connecting-using-the-default-authenticator) and [private key authentication](https://docs.snowflake.com/en/user-guide/python-connector-example.html#using-key-pair-authentication). 
+
+In the event both authentication criteria are provided, snowchange will prioritize password authentication.
+
+#### Password Authentication
 The Snowflake user password for `SNOWFLAKE_USER` is required to be set in the environment variable `SNOWSQL_PWD` prior to calling the script. snowchange will fail if the `SNOWSQL_PWD` environment variable is not set.
+
+#### Private Key Authentication
+The Snowflake user private key for `SNOWFLAKE_USER` is required to be in a file with the file path set in the environment variable `PRIVATE_KEY_PATH`. Additionally, the password for the private key file is required to be set in the environment variable `PRIVATE_KEY_PASSPHRASE`. These two environment variables must be set prior to calling the script. snowchange will fail if the `PRIVATE_KEY_PATH` and `PRIVATE_KEY_PASSPHRASE` environment variables are not set.
 
 ### Script Parameters
 

--- a/snowchange/cli.py
+++ b/snowchange/cli.py
@@ -157,6 +157,7 @@ def get_all_scripts_recursively(root_directory, verbose):
 
 def execute_snowflake_query(snowflake_database, query, autocommit, verbose):
   # Password authentication is the default
+  snowflake_password = None
   if os.getenv("SNOWFLAKE_PASSWORD") is not None and os.getenv("SNOWFLAKE_PASSWORD"):
     snowflake_password = os.getenv("SNOWFLAKE_PASSWORD")
   elif os.getenv("SNOWSQL_PWD") is not None and os.getenv("SNOWSQL_PWD"):  # Check legacy/deprecated env variable

--- a/snowchange/cli.py
+++ b/snowchange/cli.py
@@ -36,8 +36,8 @@ class JinjaExpressionTemplate(string.Template):
 def snowchange(root_folder, snowflake_account, snowflake_user, snowflake_role, snowflake_warehouse, change_history_table_override, vars, autocommit, verbose):
   # Password authentication will take priority
   if "SNOWFLAKE_PASSWORD" not in os.environ and "SNOWSQL_PWD" not in os.environ:  # We will accept SNOWSQL_PWD for now, but it is deprecated
-    if "PRIVATE_KEY_PATH" not in os.environ or "PRIVATE_KEY_PASSPHRASE" not in os.environ:
-      raise ValueError("Missing environment variable(s). SNOWFLAKE_PASSWORD must be defined for password authentication. PRIVATE_KEY_PATH and PRIVATE_KEY_PASSPHRASE must be defined for private key authentication")
+    if "SNOWFLAKE_PRIVATE_KEY_PATH" not in os.environ or "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE" not in os.environ:
+      raise ValueError("Missing environment variable(s). SNOWFLAKE_PASSWORD must be defined for password authentication. SNOWFLAKE_PRIVATE_KEY_PATH and SNOWFLAKE_PRIVATE_KEY_PASSPHRASE must be defined for private key authentication")
 
   root_folder = os.path.abspath(root_folder)
   if not os.path.isdir(root_folder):
@@ -176,12 +176,12 @@ def execute_snowflake_query(snowflake_database, query, autocommit, verbose):
       password = snowflake_password
     )
   # If no password, try private key authentication
-  elif os.getenv("PRIVATE_KEY_PATH") is not None and os.getenv("PRIVATE_KEY_PATH") and os.getenv("PRIVATE_KEY_PASSPHRASE") is not None and os.getenv("PRIVATE_KEY_PASSPHRASE"):
+  elif os.getenv("SNOWFLAKE_PRIVATE_KEY_PATH") is not None and os.getenv("SNOWFLAKE_PRIVATE_KEY_PATH") and os.getenv("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE") is not None and os.getenv("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
     print("Proceeding with private key authentication")
-    with open(os.environ["PRIVATE_KEY_PATH"], "rb") as key:
+    with open(os.environ["SNOWFLAKE_PRIVATE_KEY_PATH"], "rb") as key:
       p_key= serialization.load_pem_private_key(
           key.read(),
-          password=os.environ['PRIVATE_KEY_PASSPHRASE'].encode(),
+          password=os.environ['SNOWFLAKE_PRIVATE_KEY_PASSPHRASE'].encode(),
           backend=default_backend()
       )
 


### PR DESCRIPTION
We have a strict requirement for using private key authentication when running Snowflake scripts in our automation pipelines. This PR for **version 2.5.0** is adding support for encrypted key pair authentication based on the [docs for the Python connector](https://docs.snowflake.com/en/user-guide/python-connector-example.html#using-key-pair-authentication).

Note that I have prioritized password authentication due to the fact it was in the script first. If this logic should be changed, let me know. 